### PR TITLE
Add support for extra arguments such as authentication object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ Client session
    # To start session in async mode
    s = Session('http://localhost:8080/', enable_async=True)
 
+   # You can also pass extra arguments that are passed directly to requests or aiohttp methods,
+   # such as authentication object
+   s = Session('http://localhost:8080/',
+               request_kwargs=dict(auth=HttpBasicAuth('user', 'password'))
+
+
    # You can also use Session as a context manager. Changes are committed in the end
    # and session is closed.
    with Session(...) as s:
@@ -250,26 +256,6 @@ Deleting resources
     cust1.delete() # Mark to be deleted
     cust1.commit() # Actually delete
 
-Authentication
---------------
-
-Authentication is based on `requests.request` method, adding a callback to each request.
-
-.. code-block:: python
-
-    class authenticator:
-        def __init__(self, username, password):
-            self.username = username
-            self.password = password
-
-        def __call__(self, r):
-            r.headers['Authorization'] = '%s:%s' % (self.username,
-                self.password)
-            return r
-
-    s = Session(server_url, auth=authenticator('username', 'password'))
-
-For more info please check http://docs.python-requests.org/en/master/user/authentication/
 
 Credits
 =======

--- a/README.rst
+++ b/README.rst
@@ -254,19 +254,20 @@ Authentication
 --------------
 
 Authentication is based on `requests.request` method, adding a callback to each request.
+
 .. code-block:: python
 
-class authenticator:
-    def __init__(self, username, password):
-        self.username = username
-        self.password = password
+    class authenticator:
+        def __init__(self, username, password):
+            self.username = username
+            self.password = password
 
-    def __call__(self, r):
-        r.headers['Authorization'] = '%s:%s' % (self.username,
-            self.password)
-        return r
+        def __call__(self, r):
+            r.headers['Authorization'] = '%s:%s' % (self.username,
+                self.password)
+            return r
 
-s = Session(server_url, auth=authenticator('username', 'password'))
+    s = Session(server_url, auth=authenticator('username', 'password'))
 
 For more info please check http://docs.python-requests.org/en/master/user/authentication/
 

--- a/README.rst
+++ b/README.rst
@@ -250,6 +250,26 @@ Deleting resources
     cust1.delete() # Mark to be deleted
     cust1.commit() # Actually delete
 
+Authentication
+--------------
+
+Authentication is based on `requests.request` method, adding a callback to each request.
+.. code-block:: python
+
+class authenticator:
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+
+    def __call__(self, r):
+        r.headers['Authorization'] = '%s:%s' % (self.username,
+            self.password)
+        return r
+
+s = Session(server_url, auth=authenticator('username', 'password'))
+
+For more info please check http://docs.python-requests.org/en/master/user/authentication/
+
 Credits
 =======
 

--- a/src/jsonapi_client/objects.py
+++ b/src/jsonapi_client/objects.py
@@ -73,6 +73,8 @@ class Link(AbstractJsonObject):
             else:
                 self.href = data['href']
                 self.meta = Meta(self.session, data.get('meta', {}))
+        else:
+            self.href = None
 
     def __eq__(self, other):
         return self.href == other.href

--- a/src/jsonapi_client/objects.py
+++ b/src/jsonapi_client/objects.py
@@ -73,7 +73,8 @@ class Link(AbstractJsonObject):
             else:
                 self.href = data['href']
                 self.meta = Meta(self.session, data.get('meta', {}))
-        self.href = ''
+        else:
+            self.href = ''
 
     def __eq__(self, other):
         return self.href == other.href

--- a/src/jsonapi_client/objects.py
+++ b/src/jsonapi_client/objects.py
@@ -67,14 +67,13 @@ class Link(AbstractJsonObject):
     http://jsonapi.org/format/#document-links
     """
     def _handle_data(self, data):
-        if data is not None:
+        if data:
             if isinstance(data, str):
                 self.href = data
             else:
                 self.href = data['href']
                 self.meta = Meta(self.session, data.get('meta', {}))
-        else:
-            self.href = None
+        self.href = ''
 
     def __eq__(self, other):
         return self.href == other.href

--- a/src/jsonapi_client/objects.py
+++ b/src/jsonapi_client/objects.py
@@ -1,5 +1,5 @@
 """
-JSON API Python client 
+JSON API Python client
 https://github.com/qvantel/jsonapi-client
 
 (see JSON API specification in http://jsonapi.org/)
@@ -67,11 +67,12 @@ class Link(AbstractJsonObject):
     http://jsonapi.org/format/#document-links
     """
     def _handle_data(self, data):
-        if isinstance(data, str):
-            self.href = data
-        else:
-            self.href = data['href']
-            self.meta = Meta(self.session, data.get('meta', {}))
+        if data is not None:
+            if isinstance(data, str):
+                self.href = data
+            else:
+                self.href = data['href']
+                self.meta = Meta(self.session, data.get('meta', {}))
 
     def __eq__(self, other):
         return self.href == other.href

--- a/src/jsonapi_client/session.py
+++ b/src/jsonapi_client/session.py
@@ -124,7 +124,7 @@ class Session:
         self._server: ParseResult
         self.enable_async = enable_async
 
-        self.authObject = auth
+        self.auth_object = auth
 
         if server_url:
             self._server = urlparse(server_url)
@@ -472,7 +472,7 @@ class Session:
         import requests
         parsed_url = urlparse(url)
         logger.info('Fetching document from url %s', parsed_url)
-        response = requests.get(parsed_url.geturl(), auth=self.authObject)
+        response = requests.get(parsed_url.geturl(), auth=self.auth_object)
         if response.status_code == HttpStatus.OK_200:
             return response.json()
         else:
@@ -514,7 +514,7 @@ class Session:
 
         response = requests.request(http_method, url, json=send_json,
                                     headers={'Content-Type': 'application/vnd.api+json'},
-                                    auth=self.authObject)
+                                    auth=self.auth_object)
 
         if response.status_code not in expected_statuses:
             raise DocumentError(f'Could not {http_method.upper()} '
@@ -546,7 +546,7 @@ class Session:
         expected_statuses = expected_statuses or HttpStatus.ALL_OK
         content_type = '' if http_method == HttpMethod.DELETE else 'application/vnd.api+json'
         async with self._aiohttp_session.request(http_method, url, data=json.dumps(send_json),
-                    headers={'Content-Type': 'application/vnd.api+json'}, auth=self.authObject) as response:
+                    headers={'Content-Type': 'application/vnd.api+json'}, auth=self.auth_object) as response:
 
             if response.status not in expected_statuses:
                 raise DocumentError(f'Could not {http_method.upper()} '

--- a/src/jsonapi_client/session.py
+++ b/src/jsonapi_client/session.py
@@ -1,5 +1,5 @@
 """
-JSON API Python client 
+JSON API Python client
 https://github.com/qvantel/jsonapi-client
 
 (see JSON API specification in http://jsonapi.org/)
@@ -119,9 +119,12 @@ class Session:
     def __init__(self, server_url: str=None,
                  enable_async: bool=False,
                  schema: dict=None,
+                 auth: object=None,
                  loop: 'AbstractEventLoop'=None) -> None:
         self._server: ParseResult
         self.enable_async = enable_async
+
+        self.authObject = auth
 
         if server_url:
             self._server = urlparse(server_url)
@@ -364,7 +367,7 @@ class Session:
         Request (GET) Document from server and iterate through resources.
         If Document uses pagination, fetch results as long as there are new
         results.
-        
+
         If session is used with enable_async=True, this needs to iterated with
         async for.
 
@@ -469,7 +472,7 @@ class Session:
         import requests
         parsed_url = urlparse(url)
         logger.info('Fetching document from url %s', parsed_url)
-        response = requests.get(parsed_url.geturl())
+        response = requests.get(parsed_url.geturl(), auth=self.authObject)
         if response.status_code == HttpStatus.OK_200:
             return response.json()
         else:
@@ -510,7 +513,8 @@ class Session:
         expected_statuses = expected_statuses or HttpStatus.ALL_OK
 
         response = requests.request(http_method, url, json=send_json,
-                                    headers={'Content-Type': 'application/vnd.api+json'})
+                                    headers={'Content-Type': 'application/vnd.api+json'},
+                                    auth=self.authObject)
 
         if response.status_code not in expected_statuses:
             raise DocumentError(f'Could not {http_method.upper()} '
@@ -542,7 +546,7 @@ class Session:
         expected_statuses = expected_statuses or HttpStatus.ALL_OK
         content_type = '' if http_method == HttpMethod.DELETE else 'application/vnd.api+json'
         async with self._aiohttp_session.request(http_method, url, data=json.dumps(send_json),
-                    headers={'Content-Type': 'application/vnd.api+json'}) as response:
+                    headers={'Content-Type': 'application/vnd.api+json'}, auth=self.authObject) as response:
 
             if response.status not in expected_statuses:
                 raise DocumentError(f'Could not {http_method.upper()} '

--- a/src/jsonapi_client/session.py
+++ b/src/jsonapi_client/session.py
@@ -126,7 +126,7 @@ class Session:
         self._server: ParseResult
         self.enable_async = enable_async
 
-        self.request_kwargs: dict = request_kwargs or {}
+        self._request_kwargs: dict = request_kwargs or {}
 
         if server_url:
             self._server = urlparse(server_url)
@@ -474,7 +474,7 @@ class Session:
         import requests
         parsed_url = urlparse(url)
         logger.info('Fetching document from url %s', parsed_url)
-        response = requests.get(parsed_url.geturl(), **self.request_kwargs)
+        response = requests.get(parsed_url.geturl(), **self._request_kwargs)
         if response.status_code == HttpStatus.OK_200:
             return response.json()
         else:
@@ -494,7 +494,7 @@ class Session:
         parsed_url = urlparse(url)
         logger.info('Fetching document from url %s', parsed_url)
         async with self._aiohttp_session.get(parsed_url.geturl(),
-                                             **self.request_kwargs) as response:
+                                             **self._request_kwargs) as response:
             if response.status == HttpStatus.OK_200:
                 return await response.json(content_type='application/vnd.api+json')
             else:
@@ -517,7 +517,7 @@ class Session:
 
         response = requests.request(http_method, url, json=send_json,
                                     headers={'Content-Type': 'application/vnd.api+json'},
-                                    **self.request_kwargs)
+                                    **self._request_kwargs)
 
         if response.status_code not in expected_statuses:
             raise DocumentError(f'Could not {http_method.upper()} '
@@ -551,7 +551,7 @@ class Session:
         async with self._aiohttp_session.request(
                 http_method, url, data=json.dumps(send_json),
                 headers={'Content-Type':'application/vnd.api+json'},
-                **self.request_kwargs) as response:
+                **self._request_kwargs) as response:
 
             if response.status not in expected_statuses:
                 raise DocumentError(f'Could not {http_method.upper()} '


### PR DESCRIPTION
This patch adds support for authentication to the client.
It uses the same logic as `requests` (http://docs.python-requests.org/en/master/user/advanced/#custom-authentication).

More I added a small fix to keep in account cases when `links` can be empty (i.e. Flask-Restless pagination)