### PR TITLE
Handle empty relationship data list

### DIFF
--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -276,15 +276,14 @@ class RelationshipDict(dict):
         """
         from . import relationships as rel
         relationship_data = data.get('data')
-        if relationship_data:
-            if isinstance(relationship_data, list):
-                if not (not relation_type or relation_type == RelationType.TO_MANY):
-                    logger.error('Conflicting information about relationship')
-                return rel.MultiRelationship
-            else:
-                if not(not relation_type or relation_type == RelationType.TO_ONE):
-                    logger.error('Conflicting information about relationship')
-                return rel.SingleRelationship
+        if isinstance(relationship_data, list):
+            if not (not relation_type or relation_type == RelationType.TO_MANY):
+                logger.error('Conflicting information about relationship')
+            return rel.MultiRelationship
+        elif relationship_data:
+            if not(not relation_type or relation_type == RelationType.TO_ONE):
+                logger.error('Conflicting information about relationship')
+            return rel.SingleRelationship
         elif 'links' in data:
             return rel.LinkRelationship
         elif 'meta' in data:


### PR DESCRIPTION
I had an issue with [Fimfiction APIv2](https://www.fimfiction.net/developers/api/v2/docs) sometimes returning empty relationships:

```JSON
"relationships": {
  "tags": {
    "data": []
  },
}
```

This caused `jsonapi_client` to throw an exception:

```python
raise ValidationError('Must have either links, data or meta in relationship')
```

I've made a quick-fix that handles empty relationship data lists like any other many-to-many relationship.