### PR TITLE
iterate through relations if paginated 

### DIFF
--- a/src/jsonapi_client/relationships.py
+++ b/src/jsonapi_client/relationships.py
@@ -370,12 +370,16 @@ class LinkRelationship(AbstractRelationship):
         self.session.assert_async()
         self._document = \
             await self.session.fetch_document_by_url_async(self.links.related.url)
+        if self.session.return_link_relationship_as_iterator:
+            return self._document.iterator()
         self._resources = {(r.type, r.id): r for r in self._document.resources}
         return list(self._resources.values())
 
     def _fetch_sync(self) -> 'List[ResourceObject]':
         self.session.assert_sync()
         self._document = self.session.fetch_document_by_url(self.links.related.url)
+        if self.session.return_link_relationship_as_iterator:
+            return self._document.iterator()
         self._resources = {(r.type, r.id): r for r in self._document.resources}
         return list(self._resources.values())
 

--- a/src/jsonapi_client/session.py
+++ b/src/jsonapi_client/session.py
@@ -122,7 +122,8 @@ class Session:
                  enable_async: bool=False,
                  schema: dict=None,
                  request_kwargs: dict=None,
-                 loop: 'AbstractEventLoop'=None) -> None:
+                 loop: 'AbstractEventLoop'=None,
+                 return_link_relationship_as_iterator: bool=False,) -> None:
         self._server: ParseResult
         self.enable_async = enable_async
 
@@ -141,6 +142,7 @@ class Session:
         if enable_async:
             import aiohttp
             self._aiohttp_session = aiohttp.ClientSession(loop=loop)
+        self.return_link_relationship_as_iterator = return_link_relationship_as_iterator
 
     def add_resources(self, *resources: 'ResourceObject') -> None:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -297,6 +297,17 @@ def test_relationships_single(mocked_fetch, article_schema):
     assert article2.comment_or_author.type == 'people'
     assert article2.comment_or_author.first_name == 'Dan' \
 
+
+@pytest.mark.asyncio
+async def test_relationships_iterator(mocked_fetch, article_schema):
+    s = Session('http://localhost:8080', enable_async=True, schema=article_schema, return_link_relationship_as_iterator=True)
+    doc = await s.get('articles')
+    article, article2 = doc.resources
+    comments = article.comments
+    assert isinstance(comments, jsonapi_client.relationships.MultiRelationship)
+    assert len(comments._resource_identifiers) == 2
+
+
 @pytest.mark.asyncio
 async def test_relationships_single_async(mocked_fetch, article_schema):
     s = Session('http://localhost:8080', enable_async=True, schema=article_schema)


### PR DESCRIPTION
This PR allows returning link to relationship as an iterator. replace #10 

see https://github.com/qvantel/jsonapi-client/issues/6