### PR TITLE
Fix handling null one-to-one-relationship

### DIFF
--- a/src/jsonapi_client/relationships.py
+++ b/src/jsonapi_client/relationships.py
@@ -271,6 +271,12 @@ class SingleRelationship(AbstractRelationship):
             return None
         return self._resource_identifier.as_resource_identifier_dict()
 
+    def _value_to_identifier(self, value: R_IDENT_TYPES, type_: str='') \
+            -> 'Union[ResourceIdentifier, ResourceObject]':
+        if value is None:
+            return None
+        return super()._value_to_identifier(value, type_)
+
     def set(self, new_value: R_IDENT_TYPES, type_: str='') -> None:
 
         self._resource_identifier = self._value_to_identifier(new_value, type_)

--- a/src/jsonapi_client/relationships.py
+++ b/src/jsonapi_client/relationships.py
@@ -223,21 +223,30 @@ class SingleRelationship(AbstractRelationship):
     """
     def _handle_data(self, data):
         super()._handle_data(data)
-        self._resource_identifier = ResourceIdentifier(self.session, self._resource_data)
+        if self._resource_data is None:
+            self._resource_identifier = None
+        else:
+            self._resource_identifier = ResourceIdentifier(self.session, self._resource_data)
         del self._resource_data  # This is not intended to be used after this
 
     async def _fetch_async(self) -> 'List[ResourceObject]':
         self.session.assert_async()
         res_id = self._resource_identifier
-        res = await self.session.fetch_resource_by_resource_identifier_async(res_id)
-        self._resources = {(res.type, res.id): res}
+        if res_id is None:
+            self._resources = {None: None}
+        else:
+            res = await self.session.fetch_resource_by_resource_identifier_async(res_id)
+            self._resources = {(res.type, res.id): res}
         return list(self._resources.values())
 
     def _fetch_sync(self) -> 'List[ResourceObject]':
         self.session.assert_sync()
         res_id = self._resource_identifier
-        res = self.session.fetch_resource_by_resource_identifier(res_id)
-        self._resources = {(res.type, res.id): res}
+        if res_id is None:
+            self._resources = {None: None}
+        else:
+            res = self.session.fetch_resource_by_resource_identifier(res_id)
+            self._resources = {(res.type, res.id): res}
         return list(self._resources.values())
 
     def __bool__(self):
@@ -252,10 +261,14 @@ class SingleRelationship(AbstractRelationship):
 
     @property
     def url(self) -> str:
+        if self._resource_identifier is None:
+            return self.links.related
         return self._resource_identifier.url
 
     @property
     def as_json_resource_identifiers(self) -> dict:
+        if self._resource_identifier is None:
+            return None
         return self._resource_identifier.as_resource_identifier_dict()
 
     def set(self, new_value: R_IDENT_TYPES, type_: str='') -> None:

--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -275,15 +275,18 @@ class RelationshipDict(dict):
         :param relation_type: either 'to-one' or 'to-many'
         """
         from . import relationships as rel
-        relationship_data = data.get('data')
-        if isinstance(relationship_data, list):
-            if not (not relation_type or relation_type == RelationType.TO_MANY):
-                logger.error('Conflicting information about relationship')
-            return rel.MultiRelationship
-        elif relationship_data:
-            if not(not relation_type or relation_type == RelationType.TO_ONE):
-                logger.error('Conflicting information about relationship')
-            return rel.SingleRelationship
+        if 'data' in data:
+            relationship_data = data['data']
+            if isinstance(relationship_data, list):
+                if not (not relation_type or relation_type == RelationType.TO_MANY):
+                    logger.error('Conflicting information about relationship')
+                return rel.MultiRelationship
+            elif relationship_data is None or isinstance(relationship_data, dict):
+                if not(not relation_type or relation_type == RelationType.TO_ONE):
+                    logger.error('Conflicting information about relationship')
+                return rel.SingleRelationship
+            else:
+                raise ValidationError('Relationship data key is invalid')
         elif 'links' in data:
             return rel.LinkRelationship
         elif 'meta' in data:

--- a/tests/json/articles.json
+++ b/tests/json/articles.json
@@ -117,6 +117,35 @@
     "links": {
       "self": "http://example.com/articles/2"
     }
+  },
+  {
+    "type": "articles",
+    "id": "3",
+    "attributes": {
+      "title": "An authorless book!",
+      "nested1": {"nested": {"name": "test"}}
+    },
+    "relationships": {
+      "author": {
+        "data": null
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/3/relationships/comments",
+          "related": "http://example.com/articles/3/comments"
+        },
+        "data": []
+      },
+      "comment-or-author": {
+        "data": null
+      },
+      "comments-or-authors": {
+        "data": []
+      }
+    },
+    "links": {
+      "self": "http://example.com/articles/2"
+    }
   }
   ],
   "included": [{


### PR DESCRIPTION
According to jsonapi spec, such relationships are represented by null.

Signed-off-by: Igor Kotrasinski <i.kotrasinsk@gmail.com>