### PR TITLE
Stop following next when we have no items on current page

### DIFF
--- a/src/jsonapi_client/document.py
+++ b/src/jsonapi_client/document.py
@@ -111,12 +111,27 @@ class Document(AbstractJsonObject):
         return f'{self.resources}' if self.resources else f'{self.errors}'
 
     def _iterator_sync(self) -> 'Iterator[ResourceObject]':
+        # if we currently have no items on the page, then there's no need to yield items
+        # and check the next page
+        # we do this because there are APIs that always have a 'next' link, even when 
+        # there are no items on the page
+        if len(self.resources) == 0:
+            return
+        
         yield from self.resources
+
         if self.links.next:
             next_doc = self.links.next.fetch()
             yield from next_doc.iterator()
 
     async def _iterator_async(self) -> 'AsyncIterator[ResourceObject]':
+        # if we currently have no items on the page, then there's no need to yield items
+        # and check the next page
+        # we do this because there are APIs that always have a 'next' link, even when 
+        # there are no items on the page
+        if len(self.resources) == 0:
+            return
+        
         for res in self.resources:
             yield res
 


### PR DESCRIPTION
As per the API spec it is not needed to not show the `next` page when there are no items. 

One example could be APIs where it is really expensive or impossible to calculate total items, and as such they opt to just always render the link.

Now, with this modification if we end up on an empty page we decide to stop following the `next` page. 

Before it would loop forever. 