### PR TITLE
Fixing fetching resources without attributes (#25)

### DIFF
--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -409,11 +409,10 @@ class ResourceObject(AbstractJsonObject):
         self.links = Links(self.session, data.get('links', {}))
         self.meta = Meta(self.session, data.get('meta', {}))
 
-        self._attributes = AttributeDict(data=data['attributes'],
-                                         resource=self)
         self._relationships = RelationshipDict(
             data=data.get('relationships', {}),
             resource=self)
+        self._attributes = AttributeDict(data=data.get('attributes', {}), resource=self)
 
         if self.id:
             self.validate()


### PR DESCRIPTION
Fixes #25, where the attributes property is mandatory but under the spec can be optional.

See #29 for a previous pull-request for this issue.