### PR TITLE
fix custom_url logic: use custom_url for all types of request, not for POST only

### DIFF
--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -518,7 +518,7 @@ class ResourceObject(AbstractJsonObject):
         return HttpMethod.PATCH if self.id else HttpMethod.POST
 
     def _pre_commit(self, custom_url):
-        url = custom_url or self.post_url if self._http_method == HttpMethod.POST else self.url
+        url = custom_url or (self.post_url if self._http_method == HttpMethod.POST else self.url)
         logger.info('Committing %s to %s', self, url)
         self.validate()
         return url


### PR DESCRIPTION
Original code:
https://github.com/qvantel/jsonapi-client/blame/28d1e7b0d99ff0393ab592df2bdc2a1f966d0419/src/jsonapi_client/resourceobject.py#L521

```
    def _pre_commit(self, custom_url):
        url = custom_url or self.post_url if self._http_method == HttpMethod.POST else self.url
        logger.info('Committing %s to %s', self, url)
        self.validate()
        return url
```

Line

`url = custom_url or self.post_url if self._http_method == HttpMethod.POST else self.url
`
is interpreted by Python as
`url = (custom_url or self.post_url) if self._http_method == HttpMethod.POST else self.url
`

Original code allows using custom_url only for POST methods.
And this seems not what author expected.
