### PR TITLE
[bugfix] Changes `status_code` attribute to `status` for aiohttp.response exception handler

### DIFF
--- a/src/jsonapi_client/session.py
+++ b/src/jsonapi_client/session.py
@@ -509,9 +509,9 @@ class Session:
             if response.status == HttpStatus.OK_200:
                 return await response.json(content_type='application/vnd.api+json')
             else:
-                raise DocumentError(f'Error {response.status_code}: '
+                raise DocumentError(f'Error {response.status}: '
                                     f'{error_from_response(response)}',
-                                    errors={'status_code': response.status_code},
+                                    errors={'status_code': response.status},
                                     response=response)
 
     def http_request(self, http_method: str, url: str, send_json: dict,


### PR DESCRIPTION
When calling `aiohttp.request` on `_fetch_json_async` and the response has a status that is not 200, the block raising the Document error exception is actually throwing an AttributeError.

The reason is that aiohttp.response doesn't have `status_code` attribute (it is actually called `status`).

This PR fixes the attribute used on the exception handler block.