### PR TITLE
Prevent AttributeDict() from modifying its input

### DIFF
--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -84,6 +84,8 @@ class AttributeDict(dict):
 
         specification = self._schema.find_spec(self._resource.type, self._full_name)
 
+        # Using .pop() below modifies the data, so we make a shallow copy of it first
+        data = data.copy()
         # If there's schema for this object, we will use it to construct object.
         if specification:
             for field_name, field_spec in specification['properties'].items():


### PR DESCRIPTION
AttributeDict .pop() its “data” argument. This is fine when “data” is the top-level argument, but since the method is calling itself recursively, it modifies the objects that are values of the top-level argument, and that modifies data that the caller of jsonapi-client does not expect to be modified.