### PR TITLE
Added get(key, default=..) method to AttributeProxy, to allow dict like checking of existing variables

### DIFF
--- a/src/jsonapi_client/common.py
+++ b/src/jsonapi_client/common.py
@@ -170,6 +170,15 @@ class AttributeProxy:
         except KeyError:
             raise AttributeError
 
+    def get(self, item, default=object()):
+        # Can't use default=None as .get('foo', None) is common, so use
+        # a unique empty object with a reference check
+        if default is self.get.__defaults__[0]:
+            self.__getattr__(item)
+
+        item_json = jsonify_attribute_name(item)
+        return self[item_json] if hasattr(self, item_json) else default
+
     def __setattr__(self, key, value):
         if key == '_target_object':
             return super().__setattr__(key, value)


### PR DESCRIPTION
I'm not sure how welcome this is, but we've added a dict-like get method to our codebase so that we can perform typical dictionary checking for keys, e.g.:

    time = response.resources.get('lastTime', '01/01/2001')

Rather than having to check if lastTime exists, then setting a default if it doesn't. As with dict it's also very useful for stringing together values:

    name = resources.get('person', {}).get('name', 'Unknown')

Which dramatically improves readability, and allows you to easily default to one value if one or both of person and name don't exist.

I think this is a much more pythonic way of handling it.