### PR TITLE
Add `trailing_slash` argument to the session

### DIFF
--- a/src/jsonapi_client/document.py
+++ b/src/jsonapi_client/document.py
@@ -1,5 +1,5 @@
 """
-JSON API Python client 
+JSON API Python client
 https://github.com/qvantel/jsonapi-client
 
 (see JSON API specification in http://jsonapi.org/)
@@ -62,6 +62,8 @@ class Document(AbstractJsonObject):
                  no_cache: bool=False) -> None:
         self._no_cache = no_cache  # if true, do not store resources to session cache
         self._url = url
+        if session.trailing_slash and not self._url.endswith('/'):
+            self._url = self._url + '/'
         super().__init__(session, json_data)
 
     @property
@@ -113,11 +115,11 @@ class Document(AbstractJsonObject):
     def _iterator_sync(self) -> 'Iterator[ResourceObject]':
         # if we currently have no items on the page, then there's no need to yield items
         # and check the next page
-        # we do this because there are APIs that always have a 'next' link, even when 
+        # we do this because there are APIs that always have a 'next' link, even when
         # there are no items on the page
         if len(self.resources) == 0:
             return
-        
+
         yield from self.resources
 
         if self.links.next:
@@ -127,11 +129,11 @@ class Document(AbstractJsonObject):
     async def _iterator_async(self) -> 'AsyncIterator[ResourceObject]':
         # if we currently have no items on the page, then there's no need to yield items
         # and check the next page
-        # we do this because there are APIs that always have a 'next' link, even when 
+        # we do this because there are APIs that always have a 'next' link, even when
         # there are no items on the page
         if len(self.resources) == 0:
             return
-        
+
         for res in self.resources:
             yield res
 

--- a/src/jsonapi_client/objects.py
+++ b/src/jsonapi_client/objects.py
@@ -78,6 +78,8 @@ class Link(AbstractJsonObject):
                 self.meta = Meta(self.session, data.get('meta', {}))
         else:
             self.href = ''
+        if self.session.trailing_slash and self.href and not self.href.endswith('/'):
+            self.href = self.href + '/'
 
     def __eq__(self, other):
         return self.href == other.href
@@ -149,7 +151,7 @@ class ResourceIdentifier(AbstractJsonObject):
 
     @property
     def url(self):
-        return f'{self.session.url_prefix}/{self.type}/{self.id}'
+        return f'{self.session.url_prefix}/{self.type}/{self.id}{self.session.trailing_slash}'
 
     def __str__(self):
         return f'{self.type}: {self.id}'

--- a/src/jsonapi_client/resourceobject.py
+++ b/src/jsonapi_client/resourceobject.py
@@ -1,5 +1,5 @@
 """
-JSON API Python client 
+JSON API Python client
 https://github.com/qvantel/jsonapi-client
 
 (see JSON API specification in http://jsonapi.org/)
@@ -277,7 +277,7 @@ class RelationshipDict(dict):
         """
         From data and/or provided relation_type, determine Relationship class
         to be used.
-        
+
         :param data: Source data dictionary
         :param relation_type: either 'to-one' or 'to-many'
         """
@@ -474,7 +474,7 @@ class ResourceObject(AbstractJsonObject):
     @property
     def url(self) -> str:
         url = str(self.links.self)
-        return url or self.id and f'{self.session.url_prefix}/{self.type}/{self.id}'
+        return url or self.id and f'{self.session.url_prefix}/{self.type}/{self.id}/{self.session.trailing_slash}'
 
     @property
     def post_url(self) -> str:


### PR DESCRIPTION
Problem: 

Django and DRF have a combination of options that makes Django either redirect with 301 or return 404 error when URL is missing a trailing slash before the query params:

https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-APPEND_SLASH
https://www.django-rest-framework.org/api-guide/routers/#simplerouter

In both cases jsonapi-client fails to fetch the resource because it either faces the 404 or some headers get lost during the redirection, and response doesn't contain a valid JSON.

Suggestion:

I suggest adding an option to the session that would allow to handle this situation. 
I might miss some other places where the trailing slash should be appended though :)
