### PR TITLE
Show all errors' details

### DIFF
--- a/src/jsonapi_client/common.py
+++ b/src/jsonapi_client/common.py
@@ -99,7 +99,7 @@ class AbstractJsonObject:
 
 def error_from_response(response_content):
     try:
-        error_str = response_content['errors'][0]['title']
+        error_str = repr([ e['detail'] for e in response_content['errors'] ])
     except Exception:
         error_str = '?'
     return error_str


### PR DESCRIPTION
The title attribute of errors often does not include the most helpful
information (ex. 'must be unique') where details seems more helpful
(ex. 'email address - must be unique').

Also, raise up ALL returned errors -- not just the first one.